### PR TITLE
feat(DI-7643): disabling type checking for campaign list v2 query

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -781,6 +781,7 @@ const queryExclusionList = [
   'devices',
   'locations',
   'flatSegmentsV2',
+  'campaignsV2'
 ];
 
 /**


### PR DESCRIPTION
Disabling type checking for campaign list query as part of this story - https://fajira.futureads.com/browse/DI-7643